### PR TITLE
feat: make toast margin configurable via snackbarMarginFromEdge param

### DIFF
--- a/lib/delight_toast.dart
+++ b/lib/delight_toast.dart
@@ -31,6 +31,9 @@ class DelightToastBar {
   /// Info on each snackbar
   late final SnackBarInfo info;
 
+  /// Margin from edge of the screen to the snackbar
+  final double snackbarMarginFromEdge;
+
   /// Initialise Delight Toastbar with required parameters
   DelightToastBar(
       {this.snackbarDuration = const Duration(milliseconds: 5000),
@@ -38,9 +41,9 @@ class DelightToastBar {
       required this.builder,
       this.animationDuration = const Duration(milliseconds: 700),
       this.autoDismiss = false,
-      this.animationCurve})
-      : assert(
-            snackbarDuration.inMilliseconds > animationDuration.inMilliseconds);
+      this.animationCurve,
+      this.snackbarMarginFromEdge = 70})
+      : assert(snackbarDuration.inMilliseconds > animationDuration.inMilliseconds);
 
   /// Remove individual toasbars on dismiss
   void remove() {
@@ -61,6 +64,7 @@ class DelightToastBar {
         animationDuration: animationDuration,
         snackbarPosition: position,
         animationCurve: animationCurve,
+        snackbarMarginFromEdge: snackbarMarginFromEdge,
         autoDismiss: autoDismiss,
         getPosition: () => calculatePosition(_toastBars, this),
         getscaleFactor: () => calculateScaleFactor(_toastBars, this),

--- a/lib/toast/components/raw_delight_toast.dart
+++ b/lib/toast/components/raw_delight_toast.dart
@@ -9,6 +9,7 @@ class RawDelightToast extends StatefulWidget {
   final Curve? animationCurve;
   final bool autoDismiss;
   final DelightSnackbarPosition snackbarPosition;
+  final double snackbarMarginFromEdge;
   final Function() getscaleFactor;
   final Function() getPosition;
 
@@ -23,7 +24,8 @@ class RawDelightToast extends StatefulWidget {
       this.autoDismiss = true,
       required this.getPosition,
       this.animationCurve,
-      required this.getscaleFactor});
+      required this.getscaleFactor,
+      this.snackbarMarginFromEdge = 70});
 
   @override
   State<RawDelightToast> createState() => RawDelightToastState();
@@ -81,10 +83,10 @@ class RawDelightToastState extends State<RawDelightToast> {
       key: positionedKey,
       curve: Curves.easeOutBack,
       top: widget.snackbarPosition == DelightSnackbarPosition.top
-          ? widget.getPosition() + 70
+          ? widget.getPosition() + widget.snackbarMarginFromEdge
           : null,
       bottom: widget.snackbarPosition == DelightSnackbarPosition.bottom
-          ? widget.getPosition() + 70
+          ? widget.getPosition() + widget.snackbarMarginFromEdge
           : null,
       left: 0,
       right: 0,


### PR DESCRIPTION
This PR replaces the hardcoded 70px margin with the dynamic snackbarMarginFromEdge property, adds a default value of 70 for backward compatibility, and improves flexibility for customizing toast positioning.

###  Why is this needed?

Allows users to easily adjust the margin for toast/snackbar positioning.
Maintains backward compatibility with previous behavior.
Enhances customizability and flexibility for different UI needs.
Fixes the issue where the toast appears too low on notchless devices.

### What does it do?

Replaces the fixed 70px margin with a configurable property.
Sets a default value to prevent breaking existing implementations.
Enables more flexible toast/snackbar positioning.
Ensures correct positioning on devices without a notch.

## Before 
<img width="729" alt="image" src="https://github.com/user-attachments/assets/793bc881-5701-4c80-9bbf-ac01ddcee121" />

## After
<img width="731" alt="image" src="https://github.com/user-attachments/assets/17a59d45-38dd-4fc3-bbae-677f870c575d" />

